### PR TITLE
Add support for Taiko mainnet

### DIFF
--- a/README.md
+++ b/README.md
@@ -298,6 +298,12 @@ The library works with any EVM-compatible network. The example agents use:
 - USDC: `0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913`
 - Explorer: https://basescan.org/
 
+### Taiko Mainnet (production)
+- Chain ID: `167000`
+- RPC: `https://rpc.mainnet.taiko.xyz`
+- USDC: `0x07d83526730c7438048d55a4fc0b850e2aab6f0b`
+- Explorer: https://taikoscan.io
+
 ## Security
 
 ### Best practices

--- a/x402_a2a/core/merchant.ts
+++ b/x402_a2a/core/merchant.ts
@@ -47,6 +47,7 @@ function processPriceToAtomicAmount(
     "base-sepolia": "0x036CbD53842c5426634e7929541eC2318f3dCF7e",
     ethereum: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
     polygon: "0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174",
+    taiko: "0x07d83526730c7438048d55a4fc0b850e2aab6f0b",
   };
 
   if (typeof price === "string") {

--- a/x402_a2a/core/wallet.ts
+++ b/x402_a2a/core/wallet.ts
@@ -165,6 +165,7 @@ function getChainId(network: string): number {
     "base-sepolia": 84532,
     "ethereum": 1,
     "polygon": 137,
+    "taiko": 167000,
   };
   return chainIds[network] || 84532;
 }

--- a/x402_a2a/types/state.ts
+++ b/x402_a2a/types/state.ts
@@ -35,7 +35,7 @@ export class x402Metadata {
   static readonly ERROR_KEY = "x402.payment.error";
 }
 
-export type SupportedNetworks = "base" | "base-sepolia" | "ethereum" | "polygon";
+export type SupportedNetworks = "base" | "base-sepolia" | "ethereum" | "polygon" | "taiko";
 
 // Core x402 Protocol Types (equivalent to x402.types in Python)
 export interface EIP712Domain {


### PR DESCRIPTION
## Summary
- Add Taiko mainnet as a supported network with chain ID 167000
- Configure USDC contract address (0x07d83526730c7438048d55a4fc0b850e2aab6f0b)
- Add RPC URL (https://rpc.mainnet.taiko.xyz)
- Update documentation with Taiko mainnet configuration

## Changes
- **x402_a2a/types/state.ts**: Added "taiko" to SupportedNetworks type
- **x402_a2a/core/merchant.ts**: Added Taiko USDC address to USDC_ADDRESSES map
- **x402_a2a/core/wallet.ts**: Added Taiko chain ID (167000) to getChainId function
- **README.md**: Documented Taiko mainnet configuration details

