### PR TITLE
feat: add custom network support and prevent silent network fallbacks

### DIFF
--- a/x402_a2a/core/helpers.ts
+++ b/x402_a2a/core/helpers.ts
@@ -19,7 +19,7 @@ import {
   x402PaymentRequiredException,
   PaymentRequiredExceptionOptions,
 } from "../types/errors";
-import { PaymentRequirements } from "../types/state";
+import { PaymentRequirements, SupportedNetworks } from "../types/state";
 import { Price, TokenAmount } from "../types/config";
 import { createPaymentRequirements } from "./merchant";
 
@@ -82,7 +82,7 @@ export async function createTieredPaymentOptions(
   payToAddress: string,
   resource: string,
   tiers?: TierDefinition[],
-  network: string = "base"
+  network: SupportedNetworks = "base"
 ): Promise<PaymentRequirements[]> {
   const defaultTiers: TierDefinition[] = [
     { multiplier: 1, suffix: "basic", description: "Basic service" },

--- a/x402_a2a/core/wallet.ts
+++ b/x402_a2a/core/wallet.ts
@@ -22,6 +22,7 @@ import {
   PaymentPayload,
   ExactPaymentPayload,
   EIP3009Authorization,
+  SupportedNetworks,
 } from "../types/state";
 
 /**
@@ -115,7 +116,7 @@ export async function processPayment(
   const domain: TypedDataDomain = {
     name: requirements.extra?.name || "USDC",
     version: requirements.extra?.version || "2",
-    chainId: getChainId(requirements.network),
+    chainId: getChainId(requirements.network as SupportedNetworks),
     verifyingContract: requirements.asset,
   };
 
@@ -159,13 +160,20 @@ export async function processPayment(
 /**
  * Get chain ID for network
  */
-function getChainId(network: string): number {
+function getChainId(network: SupportedNetworks): number {
   const chainIds: Record<string, number> = {
-    "base": 8453,
+    base: 8453,
     "base-sepolia": 84532,
-    "ethereum": 1,
-    "polygon": 137,
+    ethereum: 1,
+    polygon: 137,
     "polygon-amoy": 80002,
   };
-  return chainIds[network] || 84532;
+
+  if (!(network in chainIds)) {
+    throw new Error(
+      `Unsupported network "${network}". Supported networks: ${Object.keys(chainIds).join(", ")}`
+    );
+  }
+
+  return chainIds[network];
 }

--- a/x402_a2a/executors/client.ts
+++ b/x402_a2a/executors/client.ts
@@ -93,7 +93,7 @@ export class x402ClientExecutor extends x402BaseExecutor {
       const error = e as Error;
       const failureResponse: SettleResponse = {
         success: false,
-        network: "base",
+        network: paymentRequired.accepts[0]?.network || "unknown",
         errorReason: `Payment failed: ${error.message}`,
       };
       this.utils.recordPaymentFailure(

--- a/x402_a2a/executors/server.ts
+++ b/x402_a2a/executors/server.ts
@@ -331,9 +331,11 @@ export abstract class x402ServerExecutor extends x402BaseExecutor {
     errorReason: string,
     eventQueue: EventQueue
   ): Promise<void> {
+    const lastRequirements =
+      x402ServerExecutor._paymentRequirementsStore.get(task.id)?.[0];
     const failureResponse: SettleResponse = {
       success: false,
-      network: "base",
+      network: lastRequirements?.network || "unknown",
       errorReason,
     };
 

--- a/x402_a2a/types/errors.ts
+++ b/x402_a2a/types/errors.ts
@@ -15,7 +15,7 @@
  * Protocol error types and error code mapping
  */
 
-import { PaymentRequirements } from "./state";
+import { PaymentRequirements, SupportedNetworks } from "./state";
 import { Price, TokenAmount } from "./config";
 
 export class x402Error extends Error {
@@ -57,7 +57,7 @@ export interface PaymentRequiredExceptionOptions {
   price: Price;
   payToAddress: string;
   resource: string;
-  network?: string;
+  network?: SupportedNetworks;
   description?: string;
   message?: string;
 }
@@ -98,7 +98,7 @@ export class x402PaymentRequiredException extends x402Error {
       price: options.price,
       payToAddress: options.payToAddress,
       resource: options.resource,
-      network: options.network || "base",
+      network: options.network,
       description: options.description || "Payment required for this service",
     });
 

--- a/x402_a2a/types/state.ts
+++ b/x402_a2a/types/state.ts
@@ -41,7 +41,7 @@ export type SupportedNetworks = "base" | "base-sepolia" | "ethereum" | "polygon"
 export interface EIP712Domain {
   name: string;
   version: string;
-  chainId?: string;
+  chainId?: number;
   verifyingContract?: string;
 }
 


### PR DESCRIPTION
## Summary

**Critical Security Fix**
- Removed silent network fallbacks in `merchant.ts` and `wallet.ts` that could cause mainnet payments to be routed to testnet contracts.

**Added Network Validation**
- Implemented `assertSupportedNetwork()` function to explicitly validate networks and throw descriptive errors for unsupported networks.

**Enhanced Type Safety**
- Updated types to use `SupportedNetworks` instead of generic `string` to prevent invalid network configurations.

**Fixed EIP-712 Domain**
- Changed `chainId` type from `string` to `number` for ethers compatibility.

---

## Changes

- Added explicit network validation with clear error messages  
- Removed fallback to Base Sepolia testnet in `processPriceToAtomicAmount()` and `getChainId()`  
- Updated error handling in executors to use actual network instead of hardcoded `"base"`  
- Strengthened type definitions to prevent invalid network configurations  

---

## Impact

Prevents potential fund loss from misconfigured networks by ensuring unsupported networks fail fast with clear error messages rather than silently falling back to testnet contracts.
