### PR TITLE
Support Ink mainnet

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ const paymentPayload = await processPayment(
 - **Full TypeScript support** - Complete type definitions and interfaces
 - **Ethereum wallet integration** - Built on ethers.js for signing and verification
 - **Dynamic pricing** - Set prices based on request parameters
-- **Multi-network support** - Works with Base, Base Sepolia, and other EVM chains
+- **Multi-network support** - Works with Base, Base Sepolia, Ink, and other EVM chains
 - **ERC-20 token payments** - Native support for USDC and other tokens
 - **ADK-compatible** - Works seamlessly with [ADK TypeScript](https://github.com/njraladdin/adk-typescript)
 
@@ -281,7 +281,7 @@ npm run dev
 
 ## Supported networks
 
-The library works with any EVM-compatible network. The example agents use:
+The library works with any EVM-compatible network. Built-in support includes:
 
 ### Base Sepolia (testnet)
 - Chain ID: `84532`
@@ -292,11 +292,29 @@ The library works with any EVM-compatible network. The example agents use:
   - ETH: https://www.alchemy.com/faucets/base-sepolia
   - USDC: https://faucet.circle.com/
 
-### Base Mainnet (production)
+### Base Mainnet
 - Chain ID: `8453`
 - RPC: `https://mainnet.base.org`
 - USDC: `0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913`
 - Explorer: https://basescan.org/
+
+### Ink Mainnet
+- Chain ID: `57073`
+- RPC: `https://rpc-gel.inkonchain.com`
+- USDC: `0x2D270e6886d130D724215A266106e6832161EAEd`
+- Explorer: https://explorer.inkonchain.com
+
+### Ethereum Mainnet
+- Chain ID: `1`
+- USDC: `0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48`
+
+### Polygon Mainnet
+- Chain ID: `137`
+- USDC: `0x3c499c542cEF5E3811e1192ce70d8cC03d5c3359`
+
+### Polygon Amoy (testnet)
+- Chain ID: `80002`
+- USDC: `0x41E94Eb019C0762f9Bfcf9Fb1E58725BfB0e7582`
 
 ## Security
 

--- a/merchant-agent/.env.example
+++ b/merchant-agent/.env.example
@@ -4,6 +4,14 @@ GOOGLE_API_KEY=your_api_key_here
 # Merchant Configuration
 MERCHANT_WALLET_ADDRESS=your-merchant-wallet-address
 PAYMENT_NETWORK=base-sepolia
+# Supported networks: base, base-sepolia, ethereum, polygon, polygon-amoy, ink
+# Network-specific USDC contracts:
+# - base: 0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913
+# - base-sepolia: 0x036CbD53842c5426634e7929541eC2318f3dCF7e
+# - ethereum: 0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48
+# - polygon: 0x3c499c542cEF5E3811e1192ce70d8cC03d5c3359
+# - polygon-amoy: 0x41E94Eb019C0762f9Bfcf9Fb1E58725BfB0e7582
+# - ink: 0x2D270e6886d130D724215A266106e6832161EAEd
 USDC_CONTRACT=0x036CbD53842c5426634e7929541eC2318f3dCF7e
 
 # Facilitator Configuration

--- a/x402_a2a/core/merchant.ts
+++ b/x402_a2a/core/merchant.ts
@@ -48,6 +48,7 @@ function processPriceToAtomicAmount(
     ethereum: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
     polygon: "0x3c499c542cEF5E3811e1192ce70d8cC03d5c3359",
     "polygon-amoy": "0x41E94Eb019C0762f9Bfcf9Fb1E58725BfB0e7582",
+    ink: "0x2D270e6886d130D724215A266106e6832161EAEd",
   };
 
   if (typeof price === "string") {

--- a/x402_a2a/core/wallet.ts
+++ b/x402_a2a/core/wallet.ts
@@ -166,6 +166,7 @@ function getChainId(network: string): number {
     "ethereum": 1,
     "polygon": 137,
     "polygon-amoy": 80002,
+    "ink": 57073,
   };
   return chainIds[network] || 84532;
 }

--- a/x402_a2a/types/state.ts
+++ b/x402_a2a/types/state.ts
@@ -35,7 +35,7 @@ export class x402Metadata {
   static readonly ERROR_KEY = "x402.payment.error";
 }
 
-export type SupportedNetworks = "base" | "base-sepolia" | "ethereum" | "polygon" | "polygon-amoy";
+export type SupportedNetworks = "base" | "base-sepolia" | "ethereum" | "polygon" | "polygon-amoy" | "ink";
 
 // Core x402 Protocol Types (equivalent to x402.types in Python)
 export interface EIP712Domain {


### PR DESCRIPTION
# Summary
This PR adds complete support for Ink mainnet to the x402 TypeScript implementation, enabling agents to request, verify, and settle USDC payments on Ink.

# Changes
- Added "ink" to the `SupportedNetworks` type definition
- Configured chain ID mapping (57073)
- Added Ink USDC contract address (`0x2D270e6886d130D724215A266106e6832161EAEd`)
- Updated README with comprehensive Ink network documentation
- Enhanced merchant agent .env.example with Ink configuration examples and RPC endpoint

# Impact
- Developers can now use `network: "ink"` in payment requirements to accept payments on Ink mainnet
