### PR TITLE
added support for arc testnet

### DIFF
--- a/README.md
+++ b/README.md
@@ -298,6 +298,13 @@ The library works with any EVM-compatible network. The example agents use:
 - USDC: `0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913`
 - Explorer: https://basescan.org/
 
+### Arc Testnet
+- Chain ID: `5042002`
+- RPC: `https://rpc.testnet.arc.network`
+- USDC: `0x3600000000000000000000000000000000000000`
+- Explorer: https://testnet.arcscan.app/
+- Note: Arc uses USDC as the native gas token. See the [Arc Network docs](https://docs.arc.network/) for more information.
+
 ## Security
 
 ### Best practices

--- a/merchant-agent/README.md
+++ b/merchant-agent/README.md
@@ -80,6 +80,12 @@ PAYMENT_NETWORK=polygon-amoy
 USDC_CONTRACT=0x41E94Eb019C0762f9Bfcf9Fb1E58725BfB0e7582
 ```
 
+**Arc Testnet:**
+```bash
+PAYMENT_NETWORK=arc-testnet
+USDC_CONTRACT=0x3600000000000000000000000000000000000000
+```
+
 ## Production Deployment
 
 ### Running the Server

--- a/x402_a2a/core/merchant.ts
+++ b/x402_a2a/core/merchant.ts
@@ -40,6 +40,7 @@ const SUPPORTED_NETWORKS: readonly SupportedNetworks[] = [
   "ethereum",
   "polygon",
   "polygon-amoy",
+  "arc-testnet",
 ];
 
 function assertSupportedNetwork(
@@ -66,6 +67,7 @@ function processPriceToAtomicAmount(
     ethereum: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
     polygon: "0x3c499c542cEF5E3811e1192ce70d8cC03d5c3359",
     "polygon-amoy": "0x41E94Eb019C0762f9Bfcf9Fb1E58725BfB0e7582",
+    "arc-testnet": "0x3600000000000000000000000000000000000000",
   };
 
   if (typeof price === "string") {

--- a/x402_a2a/core/wallet.ts
+++ b/x402_a2a/core/wallet.ts
@@ -167,6 +167,7 @@ function getChainId(network: SupportedNetworks): number {
     ethereum: 1,
     polygon: 137,
     "polygon-amoy": 80002,
+    "arc-testnet": 5042002,
   };
 
   if (!(network in chainIds)) {

--- a/x402_a2a/types/state.ts
+++ b/x402_a2a/types/state.ts
@@ -35,7 +35,7 @@ export class x402Metadata {
   static readonly ERROR_KEY = "x402.payment.error";
 }
 
-export type SupportedNetworks = "base" | "base-sepolia" | "ethereum" | "polygon" | "polygon-amoy";
+export type SupportedNetworks = "base" | "base-sepolia" | "ethereum" | "polygon" | "polygon-amoy" | "arc-testnet";
 
 // Core x402 Protocol Types (equivalent to x402.types in Python)
 export interface EIP712Domain {


### PR DESCRIPTION
## Add Arc Testnet Support

### Summary
Adds support for Arc testnet to the `x402_a2a` package, enabling payment processing on the Arc blockchain network.

### Changes

**Core library updates:**
- Added `"arc-testnet"` to `SupportedNetworks` type in `x402_a2a/types/state.ts`
- Added Arc testnet chain ID mapping (`5042002`) in `x402_a2a/core/wallet.ts`
- Updated network validation to include `"arc-testnet"` in `x402_a2a/core/merchant.ts`
- Added USDC contract address mapping for Arc testnet: `0x3600000000000000000000000000000000000000`

**Documentation updates:**
- Added Arc testnet configuration examples to `merchant-agent/README.md`
- Added Arc testnet network details to main `README.md`

### Arc Testnet Details
- **Chain ID**: `5042002`
- **RPC URL**: `https://rpc.testnet.arc.network`
- **USDC Contract**: `0x3600000000000000000000000000000000000000`
- **Explorer**: https://testnet.arcscan.app/
- **Network Name**: `arc-testnet`

### Usage
Configure agents to use Arc testnet:

```bash
PAYMENT_NETWORK=arc-testnet
USDC_CONTRACT=0x3600000000000000000000000000000000000000
```

### Testing
- [x] Updated all network configuration files
- [x] No linter errors introduced

### Notes
Arc is EVM-compatible and uses USDC as the native gas token. This integration follows the same pattern as other supported networks (Base, Ethereum, Polygon).