### PR TITLE
fix: add PaymentVerificationMode to close the settlement-gating exposure (#15)

### DIFF
--- a/x402_a2a/executors/server.ts
+++ b/x402_a2a/executors/server.ts
@@ -192,6 +192,12 @@ export abstract class x402ServerExecutor extends x402BaseExecutor {
         "FORMAT_ONLY verification mode active. Settling payment before executing delegate."
       );
 
+      // Tracked explicitly rather than re-derived from task.status.state:
+      // recordPaymentFailure() below sets task.status.state to "input-required"
+      // (per AP2/A2A retry guidance), never "failed", so a status-string check
+      // here would never catch a settlement failure.
+      let settlementSucceeded = false;
+
       try {
         logger.log("Calling settlePayment...");
         const settleResponse = await this.settlePayment(
@@ -205,6 +211,7 @@ export abstract class x402ServerExecutor extends x402BaseExecutor {
           logger.log("Settlement successful. Recording payment success.");
           this.utils.recordPaymentSuccess(task, settleResponse);
           x402ServerExecutor._paymentRequirementsStore.delete(task.id);
+          settlementSucceeded = true;
         } else {
           logger.warn(`Settlement failed: ${settleResponse.errorReason}`);
           const errorCode =
@@ -228,7 +235,10 @@ export abstract class x402ServerExecutor extends x402BaseExecutor {
         return;
       }
 
-      if (task.status.state === "failed") {
+      if (!settlementSucceeded) {
+        logger.warn(
+          "Settlement did not succeed; delegate (paid) work will not run."
+        );
         return;
       }
 

--- a/x402_a2a/executors/server.ts
+++ b/x402_a2a/executors/server.ts
@@ -30,7 +30,7 @@ import {
   VerifyResponse,
   PaymentPayload,
 } from "../types/state";
-import { x402ExtensionConfig } from "../types/config";
+import { x402ExtensionConfig, PaymentVerificationMode } from "../types/config";
 import {
   x402PaymentRequiredException,
   x402ErrorCode,
@@ -186,6 +186,68 @@ export abstract class x402ServerExecutor extends x402BaseExecutor {
       task.metadata = {};
     }
     task.metadata["x402_payment_verified"] = true;
+
+    if (this.config.paymentVerificationMode === PaymentVerificationMode.FORMAT_ONLY) {
+      logger.log(
+        "FORMAT_ONLY verification mode active. Settling payment before executing delegate."
+      );
+
+      try {
+        logger.log("Calling settlePayment...");
+        const settleResponse = await this.settlePayment(
+          paymentPayload,
+          paymentRequirements
+        );
+
+        logger.log(`Settlement response: ${JSON.stringify(settleResponse, null, 2)}`);
+
+        if (settleResponse.success) {
+          logger.log("Settlement successful. Recording payment success.");
+          this.utils.recordPaymentSuccess(task, settleResponse);
+          x402ServerExecutor._paymentRequirementsStore.delete(task.id);
+        } else {
+          logger.warn(`Settlement failed: ${settleResponse.errorReason}`);
+          const errorCode =
+            settleResponse.errorReason?.toLowerCase().includes("insufficient")
+              ? x402ErrorCode.INSUFFICIENT_FUNDS
+              : x402ErrorCode.SETTLEMENT_FAILED;
+          this.utils.recordPaymentFailure(task, errorCode, settleResponse);
+          x402ServerExecutor._paymentRequirementsStore.delete(task.id);
+        }
+
+        eventBus.publish(task);
+        logger.log("Settlement processing finished.");
+      } catch (error) {
+        logger.error("Exception during settlement:", error);
+        this._failPayment(
+          task,
+          x402ErrorCode.SETTLEMENT_FAILED,
+          `Settlement failed: ${error}`,
+          eventBus
+        );
+        return;
+      }
+
+      if (task.status.state === "failed") {
+        return;
+      }
+
+      try {
+        logger.log(
+          "Payment settled successfully. Executing delegate agent..."
+        );
+        await this._delegate.execute(context, eventBus);
+        logger.log("Delegate agent execution finished.");
+      } catch (error) {
+        logger.error(
+          "Exception during delegate execution after payment was already settled successfully. " +
+            "This is a post-payment service-delivery failure, not a payment failure:",
+          error
+        );
+      }
+
+      return;
+    }
 
     try {
       logger.log("Executing delegate agent...");

--- a/x402_a2a/types/config.ts
+++ b/x402_a2a/types/config.ts
@@ -17,6 +17,27 @@
 
 export const X402_EXTENSION_URI = "https://github.com/google-a2a/a2a-x402/v0.1";
 
+/**
+ * Controls how strictly the executor treats verifyPayment's result before
+ * running delegate (paid) work versus settling. See dabit3/a2a-x402-typescript#15
+ * and the equivalent fix landed for the Python executor in
+ * google-agentic-commerce/a2a-x402#145.
+ *
+ * - FORMAT_ONLY: verifyPayment only checks the payment payload's signature/
+ *   structure and does NOT guarantee funds will actually settle. In this mode
+ *   the executor settles the payment BEFORE running delegate.execute(), so
+ *   delegate (potentially irreversible, paid) work never runs against a
+ *   payment that could still fail to settle.
+ * - SETTLEMENT_CHECK (default): preserves the executor's existing behavior —
+ *   verify, then run delegate.execute(), then settle. Safe when delegate work
+ *   is cheap/reversible, or when verifyPayment's implementation already
+ *   confirms the payment is on-chain before returning isValid: true.
+ */
+export enum PaymentVerificationMode {
+  FORMAT_ONLY = "format_only",
+  SETTLEMENT_CHECK = "settlement_check",
+}
+
 export interface TokenAmount {
   value: string;
   asset: string;
@@ -30,6 +51,7 @@ export interface x402ExtensionConfig {
   version?: string;
   x402Version?: number;
   required?: boolean;
+  paymentVerificationMode?: PaymentVerificationMode;
 }
 
 export const DEFAULT_X402_EXTENSION_CONFIG: x402ExtensionConfig = {
@@ -37,6 +59,7 @@ export const DEFAULT_X402_EXTENSION_CONFIG: x402ExtensionConfig = {
   version: "0.1",
   x402Version: 1,
   required: true,
+  paymentVerificationMode: PaymentVerificationMode.SETTLEMENT_CHECK,
 };
 
 export interface x402ServerConfig {


### PR DESCRIPTION
Closes #15.

This port matches the fix already discussed and merged for the sibling Python executor in google-agentic-commerce/a2a-x402#145, applying the same resolution the maintainers there landed on for the identical ordering question.

**The issue:** `_processPaidRequest` in `x402_a2a/executors/server.ts` currently runs `verifyPayment` → `delegate.execute()` → `settlePayment`, always in that order. If `verifyPayment` only validates the payment payload's format/signature (rather than confirming actual on-chain settlement), a delegate can perform paid, potentially irreversible work before it's known whether settlement will actually succeed. If `settlePayment` later fails, `recordPaymentFailure` runs, but the delegate has already executed.

**The fix (additive, non-breaking):** adds a `PaymentVerificationMode` enum (`FORMAT_ONLY` | `SETTLEMENT_CHECK`) and a `paymentVerificationMode` field on `x402ExtensionConfig`, defaulting to `SETTLEMENT_CHECK`.

- `SETTLEMENT_CHECK` (default) — unchanged behavior: verify → delegate.execute() → settle. Every existing integration keeps working exactly as today with zero config changes.
- `FORMAT_ONLY` — opt-in for merchants whose `verifyPayment` implementation is format/signature-only: settle happens *before* `delegate.execute()`, so a settlement failure means the delegate never runs at all, closing the exposure described in #15.

I validated the control-flow logic (both branches, including the settlement-fails-so-delegate-must-not-run case) with a standalone simulation before writing the real change — see the async ordering test in the PR discussion if useful. I was not able to run this repo's actual TypeScript build/test suite locally (no network access in my sandbox to install `@a2a-js/sdk` and other deps), so please run CI/tsc as the real check — I've kept every other method (`_findMatchingPaymentRequirement`, `_extractPaymentRequirementsFromContext`, `_handlePaymentRequiredException`, `_failPayment`) untouched and the default-mode code path byte-for-byte identical to today's to minimize risk.

Happy to adjust naming/shape if you'd rather mirror `#145`'s three-mode (`FORMAT_ONLY`/`SETTLEMENT_CHECK`/`SETTLEMENT_FINAL`) enum exactly — kept it to two modes here since this executor doesn't currently have a confirmations/finality parameter to hang a third mode off of, but can add it if you want parity.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/dabit3/a2a-x402-typescript/pull/22" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->